### PR TITLE
Fix l2bridge conf creation

### DIFF
--- a/docs/09b-bootstrapping-windows-workers.md
+++ b/docs/09b-bootstrapping-windows-workers.md
@@ -284,9 +284,9 @@ Set-Content ${l2bridgeConf} `
             }
         }
     ]
-}'.replace('POD_CIDR', ${podCidr})`
-.replace('POD_ENDPOINT_GW', ${podEndpointGateway})`
-.replace('VETH_IP', ${vethIp})
+}'.replace('POD_CIDR', ${podCidr}).`
+replace('POD_ENDPOINT_GW', ${podEndpointGateway}).`
+replace('VETH_IP', ${vethIp})
 ```
 
 See [CNI config explanation](cni-config-explanation.md) for an explanation of


### PR DESCRIPTION
For some reason with the backtick escaped newlines I was getting 
```
Set-Content : A positional parameter cannot be found that accepts argument '.replace'.
At line:1 char:1
+ Set-Content ${l2bridgeConf} `
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-Content], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.SetContentCommand
```

when trying to run this.